### PR TITLE
Range formatter test

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(fbstring)
 add_subdirectory(address)
 add_subdirectory(socketaddress)
+add_subdirectory(range)

--- a/src/range/CMakeLists.txt
+++ b/src/range/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(range range.cpp)
+
+target_link_libraries(range PRIVATE folly)
+
+install(TARGETS range
+	RUNTIME DESTINATION ${INSTALL_DIR})

--- a/src/range/range.cpp
+++ b/src/range/range.cpp
@@ -8,22 +8,46 @@ void printStringPiece(std::string _piece) {
   std::cout << str << std::endl;
 }
 
-// void printIntArray(int arr[], int size) {
-//   int array[size] = arr;
-//   std::cout << str << std::endl;
-// }
+template <typename T>
+Range<const T*> RangeFromVector(std::vector<T> vec) {
+  auto range = Range<const T*>(&vec[0], vec.size());
+  return range;
+}
+
+ByteRange ByteRangeFromStringPiece(std::string _piece) {
+  StringPiece str(_piece);
+  ByteRange byter(str);
+  return byter;
+}
+
+MutableByteRange MutByteRangeFromStringPiece(std::string _piece) {
+  MutableStringPiece str(&_piece.front(), _piece.size());
+  MutableByteRange byter(str);
+  return byter;
+}
 
 int main() {
   // Test simple StringPieces
   printStringPiece("Hello");
   printStringPiece("Hello, World!");
-  printStringPiece("12345067891");
+  printStringPiece("1234567890");
   
-  // Test whether null char is handled
-  // Should only show "Test"
+  // Test whether null char is handled. Should only show "Test"
   printStringPiece("Test\0Null");
 
-  // What else?
+  // From vectors
+  RangeFromVector(std::vector<uint32_t>({ 1, 2, 3, 4 }));
+  RangeFromVector(std::vector<float_t>({ 1.0, 2.0, 3.0 }));
+  RangeFromVector(std::vector<char32_t>({ 'A', 'B' }));
+
+  // Simple ByteRange
+  ByteRangeFromStringPiece("Hello, World!");
+  // Mutable ByteRange
+  MutByteRangeFromStringPiece("Hello, World!");
+
+  // Lastly, empty array
+  std::array<int, 0> empty{};
+  constexpr auto EmptyRange = Range<const int*>{empty};
 
   return 0;
 }

--- a/src/range/range.cpp
+++ b/src/range/range.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <folly/Range.h>
+
+using namespace folly;
+
+void printStringPiece(std::string _piece) {
+  StringPiece str(_piece);
+  std::cout << str << std::endl;
+}
+
+// void printIntArray(int arr[], int size) {
+//   int array[size] = arr;
+//   std::cout << str << std::endl;
+// }
+
+int main() {
+  // Test simple StringPieces
+  printStringPiece("Hello");
+  printStringPiece("Hello, World!");
+  printStringPiece("12345067891");
+  
+  // Test whether null char is handled
+  // Should only show "Test"
+  printStringPiece("Test\0Null");
+
+  // What else?
+
+  return 0;
+}

--- a/src/range/range_formatter.py
+++ b/src/range/range_formatter.py
@@ -17,12 +17,10 @@ def summary(valobj, dict):
                 return str(start)
             return "(folly::StringPiece) " + summary
         else:
-            return "folly::Range size=" + str(
-                SyntheticFormatter.get_range_length(valobj)
-            )
+            return f"(folly::Range) <{SyntheticFormatter.get_item_type(valobj)}> [{SyntheticFormatter.get_range_length(valobj)}]"
 
     except Exception:
-        return "folly::Range"
+        return "(folly::Range)"
 
 
 class SyntheticFormatter:
@@ -55,7 +53,7 @@ class SyntheticFormatter:
             .GetChildMemberWithName("e_")
             .GetValueAsUnsigned()
         )
-        return (end - start) / itemSize
+        return (end - start) // itemSize
 
     def num_children(self):
         if SyntheticFormatter.is_string_piece(self.valobj):

--- a/src/range/range_formatter.py
+++ b/src/range/range_formatter.py
@@ -15,9 +15,9 @@ def summary(valobj, dict):
             summary = start.GetSummary()
             if summary is None:
                 return str(start)
-            return "(folly::StringPiece) " + summary
+            return summary
         else:
-            return f"(folly::Range) <{SyntheticFormatter.get_item_type(valobj)}> [{SyntheticFormatter.get_range_length(valobj)}]"
+            return f"size={SyntheticFormatter.get_range_length(valobj)}"
 
     except Exception:
         return "(folly::Range)"

--- a/src/range/test_range.py
+++ b/src/range/test_range.py
@@ -49,30 +49,30 @@ c
 """
 
         expected = """
-(folly::StringPiece) str = (folly::StringPiece) "Hello"
-(folly::StringPiece) $0 = (folly::StringPiece) "Hello"
+(folly::StringPiece) str = "Hello"
+(folly::StringPiece) $0 = "Hello"
 Hello
-(folly::StringPiece) str = (folly::StringPiece) "Hello, World!"
-(folly::StringPiece) $1 = (folly::StringPiece) "Hello, World!"
+(folly::StringPiece) str = "Hello, World!"
+(folly::StringPiece) $1 = "Hello, World!"
 Hello, World!
-(folly::StringPiece) str = (folly::StringPiece) "1234567890"
-(folly::StringPiece) $2 = (folly::StringPiece) "1234567890"
+(folly::StringPiece) str = "1234567890"
+(folly::StringPiece) $2 = "1234567890"
 1234567890
-(folly::StringPiece) str = (folly::StringPiece) "Test"
-(folly::StringPiece) $3 = (folly::StringPiece) "Test"
+(folly::StringPiece) str = "Test"
+(folly::StringPiece) $3 = "Test"
 Test
-(folly::Range<const unsigned int *>) range = (folly::Range) <const unsigned int *> [4]
-(folly::Range<const unsigned int *>) $4 = (folly::Range) <const unsigned int *> [4]
-(folly::Range<const float *>) range = (folly::Range) <const float *> [3]
-(folly::Range<const float *>) $5 = (folly::Range) <const float *> [3]
-(folly::Range<const char32_t *>) range = (folly::Range) <const char32_t *> [2]
-(folly::Range<const char32_t *>) $6 = (folly::Range) <const char32_t *> [2]
-(folly::ByteRange) byter = (folly::Range) <const unsigned char *> [13]
-(folly::ByteRange) $7 = (folly::Range) <const unsigned char *> [13]
-(folly::MutableByteRange) byter = (folly::Range) <unsigned char *> [13]
-(folly::MutableByteRange) $8 = (folly::Range) <unsigned char *> [13]
-(const folly::Range<const int *>) EmptyRange = (folly::Range) <const int *> [0]
-(const folly::Range<const int *>) $9 = (folly::Range) <const int *> [0]
+(folly::Range<const unsigned int *>) range = size=4
+(folly::Range<const unsigned int *>) $4 = size=4
+(folly::Range<const float *>) range = size=3
+(folly::Range<const float *>) $5 = size=3
+(folly::Range<const char32_t *>) range = size=2
+(folly::Range<const char32_t *>) $6 = size=2
+(folly::ByteRange) byter = size=13
+(folly::ByteRange) $7 = size=13
+(folly::MutableByteRange) byter = size=13
+(folly::MutableByteRange) $8 = size=13
+(const folly::Range<const int *>) EmptyRange = size=0
+(const folly::Range<const int *>) $9 = size=0
 """.strip()
 
         self.assertEqual(expected, self.run_lldb("range", script))

--- a/src/range/test_range.py
+++ b/src/range/test_range.py
@@ -7,4 +7,72 @@ class FollyRangeTest(LLDBTestCase):
         return path.join(curr_dir, "range_formatter.py")
 
     def test_range(self):
-        pass
+        script = """
+b range.cpp:8
+b range.cpp:14
+b range.cpp:20
+b range.cpp:26
+b range.cpp:50
+r
+script lldb.debugger.HandleCommand("frame var str")
+script lldb.debugger.HandleCommand("p str")
+c
+script lldb.debugger.HandleCommand("frame var str")
+script lldb.debugger.HandleCommand("p str")
+c
+script lldb.debugger.HandleCommand("frame var str")
+script lldb.debugger.HandleCommand("p str")
+c
+script lldb.debugger.HandleCommand("frame var str")
+script lldb.debugger.HandleCommand("p str")
+c
+script lldb.debugger.HandleCommand("frame var range")
+script lldb.debugger.HandleCommand("p range")
+c
+script lldb.debugger.HandleCommand("frame var range")
+script lldb.debugger.HandleCommand("p range")
+c
+script lldb.debugger.HandleCommand("frame var range")
+script lldb.debugger.HandleCommand("p range")
+c
+script lldb.debugger.HandleCommand("frame var byter")
+script lldb.debugger.HandleCommand("p byter")
+c
+script lldb.debugger.HandleCommand("frame var byter")
+script lldb.debugger.HandleCommand("p byter")
+c
+n
+n
+script lldb.debugger.HandleCommand("frame var EmptyRange")
+script lldb.debugger.HandleCommand("p EmptyRange")
+c
+"""
+
+        expected = """
+(folly::StringPiece) str = (folly::StringPiece) "Hello"
+(folly::StringPiece) $0 = (folly::StringPiece) "Hello"
+Hello
+(folly::StringPiece) str = (folly::StringPiece) "Hello, World!"
+(folly::StringPiece) $1 = (folly::StringPiece) "Hello, World!"
+Hello, World!
+(folly::StringPiece) str = (folly::StringPiece) "1234567890"
+(folly::StringPiece) $2 = (folly::StringPiece) "1234567890"
+1234567890
+(folly::StringPiece) str = (folly::StringPiece) "Test"
+(folly::StringPiece) $3 = (folly::StringPiece) "Test"
+Test
+(folly::Range<const unsigned int *>) range = (folly::Range) <const unsigned int *> [4]
+(folly::Range<const unsigned int *>) $4 = (folly::Range) <const unsigned int *> [4]
+(folly::Range<const float *>) range = (folly::Range) <const float *> [3]
+(folly::Range<const float *>) $5 = (folly::Range) <const float *> [3]
+(folly::Range<const char32_t *>) range = (folly::Range) <const char32_t *> [2]
+(folly::Range<const char32_t *>) $6 = (folly::Range) <const char32_t *> [2]
+(folly::ByteRange) byter = (folly::Range) <const unsigned char *> [13]
+(folly::ByteRange) $7 = (folly::Range) <const unsigned char *> [13]
+(folly::MutableByteRange) byter = (folly::Range) <unsigned char *> [13]
+(folly::MutableByteRange) $8 = (folly::Range) <unsigned char *> [13]
+(const folly::Range<const int *>) EmptyRange = (folly::Range) <const int *> [0]
+(const folly::Range<const int *>) $9 = (folly::Range) <const int *> [0]
+""".strip()
+
+        self.assertEqual(expected, self.run_lldb("range", script))

--- a/src/range/test_range.py
+++ b/src/range/test_range.py
@@ -1,0 +1,10 @@
+from common import LLDBTestCase
+from os import path
+
+class FollyRangeTest(LLDBTestCase):
+    def get_formatter_path(self):
+        curr_dir = path.abspath(path.dirname(path.realpath(__file__)))
+        return path.join(curr_dir, "range_formatter.py")
+
+    def test_range(self):
+        pass


### PR DESCRIPTION
I've made the `Range` formatter such that for `Range`s other than `StringPiece`, it will display this
`(folly::Range) <type> [size]`

For example with range from empty array it shows this when you run `p er`
`(const folly::Range<const int *>) er = (folly::Range) <const int *> [0]`